### PR TITLE
Add DWARF files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /bin/
 /.shards/
 bc_flags
+*.dwarf


### PR DESCRIPTION
DWARF is a debugging file format.